### PR TITLE
switch compression from zstd to xz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ debian-package: quilt/mod_authnz_external
 	cp -R debian quilt/mod_authnz_external/
 	cd quilt && tar -xvzf mod_authnz_externallibapache2-mod-authnz-external-$(version).tar.xz
 	cp -R quilt/phokz-mod-auth-external-*/* quilt/mod_authnz_external/
-	cd quilt/mod_authnz_external && debuild -us -uc
+	cd quilt/mod_authnz_external && debuild -us -uc -Zxz
 
 debsign:
 	cd quilt && debsign libapache2-mod-authnz-external_$(version)_amd64.changes

--- a/debian/rules
+++ b/debian/rules
@@ -6,5 +6,8 @@ override_dh_auto_build:
 override_dh_auto_install:
 	# handled by dh_install
 
+override_dh_builddeb:
+	dh_builddeb -- -Zxz
+
 %:
 	dh $@ --with apache2


### PR DESCRIPTION
This fixes the [strange build issue](https://github.com/carrvo/debian-libapache2-mod-authnz-external/issues/6) that the [mentors package](https://mentors.debian.net/package/libapache2-mod-authnz-external/) was spitting out.

Essentially, `dpkg-deb` defaulted to `zstd` (on Ubuntu 24 LTS) but Debian (at least mentors.debian.net) has yet to support it.